### PR TITLE
Fix NULL pointer dereference that occurs when byte swapping is needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,12 +129,15 @@ fi
 AC_SUBST(DIFF)
 AC_SUBST(DIFF_OPTS)
 
-# We use  cmp and cdparanoia in cd-paranoia regression testing
-AC_PATH_PROG(CMP, cmp, no)
-AC_SUBST(CMP)
+# We use cmp, dd, and wc in cd-paranoia regression testing
+AC_PATH_PROG([CMP], [cmp], [no])
+AC_SUBST([CMP])
 
-AC_PATH_PROG(OLD_CDPARANOIA, cdparanoia, no)
-AC_SUBST(OLD_CDPARANOIA)
+AC_PATH_PROG([DD], [dd], [no])
+AC_SUBST([DD])
+
+AC_PATH_PROG([WC], [wc], [no])
+AC_SUBST([WC])
 
 dnl headers
 
@@ -440,6 +443,7 @@ AC_CONFIG_FILES([
 
 # AC_CONFIG_FILES([po/Makefile])
 AC_CONFIG_FILES([test/check_paranoia.sh], [chmod +x test/check_paranoia.sh])
+AC_CONFIG_FILES([test/endian.sh], [chmod +x test/endian.sh])
 AC_OUTPUT
 
 AC_MSG_NOTICE([

--- a/lib/cdda_interface/interface.c
+++ b/lib/cdda_interface/interface.c
@@ -155,7 +155,7 @@ cdio_cddap_read_timed(cdrom_drive_t *d, void *buffer, lsn_t beginsector,
 	if ( d->bigendianp == -1 ) /* not determined yet */
 	  d->bigendianp = data_bigendianp(d);
 
-	if ( d->b_swap_bytes && d->bigendianp != bigendianp() ) {
+	if ( buffer && d->b_swap_bytes && d->bigendianp != bigendianp() ) {
 	  int i;
 	  uint16_t *p=(uint16_t *)buffer;
 	  long els=sectors*CDIO_CD_FRAMESIZE_RAW/2;

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -9,6 +9,10 @@
 /cd-paranoia.log
 /cdda-1.raw
 /cdda-2.raw
+/cdda-be.bin
+/cdda-be.cue
+/cdda-le.bin
+/cdda-le.cue
 /cdda-good.raw
 /cdda-jitter.raw
 /cdda-underrun.raw
@@ -20,6 +24,7 @@
 /check_nrg.sh
 /check_paranoia.sh
 /check_sizeof
+/endian.sh
 /isofs-m1.bin
 /test_lib_driver_util
 /testassert

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,7 +15,7 @@ DATA_DIR       = @abs_top_srcdir@/test/data
 
 AM_CPPFLAGS = -I$(top_srcdir) $(LIBCDIO_CFLAGS) $(LIBCDIO_PARANOIA_CFLAGS)
 
-check_SCRIPTS = check_paranoia.sh
+check_SCRIPTS = check_paranoia.sh endian.sh
 # If we beefed this up so it checked to see if a CD-DA was loaded
 # it could be an automatic test. But for now, not so.
 #               check_paranoia.sh
@@ -28,6 +28,6 @@ EXTRA_DIST = $(check_SCRIPTS) $(check_DATA)
 
 TESTS = $(check_PROGRAMS) $(check_SCRIPTS)
 
-MOSTLYCLEANFILES = core core.* *.dump cdda-orig.wav cdda-try.wav *.raw
+MOSTLYCLEANFILES = core core.* *.dump cdda-orig.wav cdda-try.wav *.raw *.bin *.cue
 
 test: check-am

--- a/test/endian.sh.in
+++ b/test/endian.sh.in
@@ -1,0 +1,59 @@
+#!/bin/sh
+#
+# Perform a round-trip test between big-endian and little-endian
+# BIN/CUE to see if we can read both files correctly.
+#
+set -e
+: ${CMP:="@CMP@"}
+: ${WC:="@WC@"}
+: ${abs_builddir:="@abs_builddir@"}
+: ${abs_srcdir:="@abs_srcdir@"}
+: ${abs_top_builddir:="@abs_top_builddir@"}
+
+cd_paranoia="${abs_top_builddir}/src/cd-paranoia@EXEEXT@"
+
+orig_le_cue_file="${abs_srcdir}/data/cdda.cue"
+orig_le_bin_file="${abs_srcdir}/data/cdda.bin"
+
+be_cue_file="${abs_builddir}/cdda-be.cue"
+be_bin_file="${abs_builddir}/cdda-be.bin"
+
+le_cue_file="${abs_builddir}/cdda-le.cue"
+le_bin_file="${abs_builddir}/cdda-le.bin"
+
+if test "${CMP}" = no; then
+    echo "Don't see 'cmp' program. Test skipped."
+    exit 77
+
+elif test "${WC}" = no; then
+    echo "Don't see 'wc' program. Test skipped."
+    exit 77
+fi
+
+# Convert from little-endian to big-endian.
+cat "${orig_le_cue_file}" > "${be_cue_file}"
+${cd_paranoia} -d "${orig_le_cue_file}" -v -R -- "1-" "${be_bin_file}"
+
+# The contents of these two .bin files should differ, but they should
+# have the same length.
+if test `${WC} -c < "${orig_le_bin_file}"` -ne `${WC} -c < "${be_bin_file}"`; then
+    echo "** File sizes differ after byte swap"
+    exit 3
+
+elif ${CMP} -s "${orig_le_bin_file}" "${be_bin_file}"; then
+    echo "** Identical raw file after byte swap"
+    exit 3
+fi
+
+# Convert it back to little-endian.
+cat "${be_cue_file}" > "${le_cue_file}"
+${cd_paranoia} -d "${be_cue_file}" -v -r -- "1-" "${le_bin_file}"
+
+# It should round-trip to the original file.
+if ${CMP} "${le_bin_file}" "${orig_le_bin_file}"; then
+    echo "** Identical raw file after round-trip"
+    exit 0
+else
+    echo "** Raw files differ after round-trip"
+    exit 3
+fi


### PR DESCRIPTION
cdrom_cache_handler() calls cdio_cddap_read_timed() with buffer == NULL. When this happens on a platform where byte swapping is needed, the latter crashes for dereferencing a NULL pointer.