### PR TITLE
Create test for multiple matches bug

### DIFF
--- a/test/.gitignore
+++ b/test/.gitignore
@@ -15,6 +15,7 @@
 /cdda-le.cue
 /cdda-good.raw
 /cdda-jitter.raw
+/cdda-matches.raw
 /cdda-underrun.raw
 /cdda.bin
 /cdda.raw

--- a/test/check_paranoia.sh.in
+++ b/test/check_paranoia.sh.in
@@ -10,6 +10,7 @@ if test ! -d "$abs_top_srcdir" ; then
 fi
 
 cue_file=$abs_top_srcdir/test/data/cdda.cue
+cue_file2=$abs_top_srcdir/test/data/cdda2.cue
 
 if test "@CMP@" != no ; then
   cd_paranoia=$abs_top_builddir/src/cd-paranoia@EXEEXT@ 
@@ -71,6 +72,21 @@ if test "@CMP@" != no ; then
   else
     echo "** under-run + jitter correction problem"
     exit 3
+  fi
+  if test -f $abs_top_builddir/test/data/cdda2.bin ; then
+      $cd_paranoia -d $cue_file2 -v -r -- "1-"
+      if test $? -ne 0 ; then
+          exit 6
+      fi
+      mv cdda.raw cdda-matches.raw
+      if @CMP@ cdda-matches.raw $abs_top_builddir/test/data/cdda2.bin ; then
+          echo "** multiple matches okay"
+      else
+          echo "** multiple matches problem"
+          exit 3
+      fi
+  else
+      echo "** multiple matches skipped (data file not present)"
   fi
   ### FIXME: medium jitter is known to fail. Investigate.
   ### FIXME: large jitter is known to fail. Investigate.

--- a/test/data/Makefile.am
+++ b/test/data/Makefile.am
@@ -1,5 +1,6 @@
 check_DATA = \
 	cdda.bin       \
-	cdda.cue       
+	cdda.cue       \
+	cdda2.cue
 
 EXTRA_DIST = $(check_DATA)

--- a/test/data/cdda2.cue
+++ b/test/data/cdda2.cue
@@ -1,0 +1,7 @@
+TITLE "Join us now we have the software"
+CATALOG 0000010271955
+PERFORMER "Richard Stallman"
+FILE "BOING.BIN" BINARY
+  TRACK 01 AUDIO
+    FLAGS DCP
+    INDEX 01 00:00:00


### PR DESCRIPTION
The test data is pretty large, but since the bug only happens in the places
where paranoia tries to merge blocks we need to have at least two blocks and
these are around 2.5MB.