### PR TITLE
configure.ac: fix out-of-tree tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,7 +243,9 @@ dnl native_abs_top_srcdir is used here.
 case $srcdir in
   .)  # We are building in place.
    native_abs_top_srcdir=$ac_pwd ;;
+  changequote(`,')
   [\\/]* | ?:[\\/]* )  # Absolute name.
+  changequote([,])
     native_abs_top_srcdir=$srcdir ;;
   *) # Relative name.
     native_abs_top_srcdir=$ac_pwd/$srcdir ;;


### PR DESCRIPTION
To reproduce the test failure one needs to run
configure using absolute path in a directory
outside source tree. For example:

    $ $(pwd)/../libcdio-paranoia/configure
    $ make
    $ make check

This will cause 'native_abs_top_srcdir' to contain wrong path.

It happens because '[]' is an escape in autoconf.
As a the following configure.ac snippet:
```
    [\\/]* | ?:[\\/]* )  # Absolute name.
```
gets translated into the following shell code:
```
    \\/* | ?:\\/* )  # Absolute name.
```

The fix is to change quotes from '[]' for a short while.

Reported-by: eroen
Reported-by: Paolo Pedroni
Bug: https://bugs.gentoo.org/546388
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>