### PR TITLE
Do not attempt to call a NULL callback (issue #15)

### DIFF
--- a/lib/paranoia/paranoia.c
+++ b/lib/paranoia/paranoia.c
@@ -2615,7 +2615,8 @@ static void cdrom_cache_handler(cdrom_paranoia_t *p, int lba, void(*callback)(lo
   if(cdda_read_timed(p->d,NULL,seekpos,1,&ms)==1)
     if(seekpos<p->cdcache_begin && ms<MIN_SEEK_MS)
       if(cdio_get_driver_id(p->d->p_cdio)==cdio_os_driver)
-        callback(seekpos*CD_FRAMEWORDS,PARANOIA_CB_CACHEERR);
+        if (callback)
+          (*callback)(seekpos*CD_FRAMEWORDS,PARANOIA_CB_CACHEERR);
   cdrom_cache_update(p,seekpos,1);
   return;
 }


### PR DESCRIPTION
Furthermore, the call is written in a manner consistent with the other
calls to the callback in the file.