### PR TITLE
Add check if linker supports version scripts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -298,6 +298,9 @@ fi
 
 AM_CONDITIONAL(CYGWIN, test "x$CYGWIN" = "xyes")
 
+dnl include check if LD supports linker scripts
+gl_LD_VERSION_SCRIPT
+
 dnl Checks for header files.
 
 LIBCDIO_CDDA_LIBS='$(top_builddir)/lib/cdda_interface/libcdio_cdda.la'

--- a/lib/cdda_interface/Makefile.am
+++ b/lib/cdda_interface/Makefile.am
@@ -122,7 +122,11 @@ LIBS = $(LIBCDIO_LIBS) @LIBS@ @COS_LIB@
 libcdio_cdda_la_MAJOR = $(shell expr $(libcdio_cdda_la_CURRENT) - $(libcdio_cdda_la_AGE))
 if VERSION_SCRIPT
 if BUILD_VERSIONED_LIBS
+if HAVE_LD_VERSION_SCRIPT
 libcdio_cdda_la_LDFLAGS = $(libcdio_cdda_la_ldflags) -Wl,--version-script=libcdio_cdda.la.ver
+else !HAVE_LD_VERSION_SCRIPT
+libcdio_cdda_la_LDFLAGS = $(libcdio_cdda_la_ldflags)
+endif # HAVE_LD_VERSION_SCRIPT
 libcdio_cdda_la_DEPENDENCIES = libcdio_cdda.la.ver
 
 libcdio_cdda.la.ver: $(libcdio_cdda_la_OBJECTS) $(srcdir)/libcdio_cdda.sym

--- a/lib/paranoia/Makefile.am
+++ b/lib/paranoia/Makefile.am
@@ -135,7 +135,11 @@ LIBS = $(LIBCDIO_LIBS) $(LIBCDIO_CDDA_LIBS)
 libcdio_paranoia_la_MAJOR = $(shell expr $(libcdio_paranoia_la_CURRENT) - $(libcdio_paranoia_la_AGE))
 if VERSION_SCRIPT
 if BUILD_VERSIONED_LIBS
+if HAVE_LD_VERSION_SCRIPT
 libcdio_paranoia_la_LDFLAGS = $(libcdio_paranoia_la_ldflags) -Wl,--version-script=libcdio_paranoia.la.ver
+else !HAVE_LD_VERSION_SCRIPT
+libcdio_paranoia_la_LDFLAGS = $(libcdio_paranoia_la_ldflags)
+endif # HAVE_LD_VERSION_SCRIPT
 libcdio_paranoia_la_DEPENDENCIES = libcdio_paranoia.la.ver
 
 libcdio_paranoia.la.ver: $(libcdio_paranoia_la_OBJECTS) $(srcdir)/libcdio_paranoia.sym

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,2 +1,3 @@
 /*.m4
+!ld-version-script.m4
 /*~

--- a/m4/ld-version-script.m4
+++ b/m4/ld-version-script.m4
@@ -1,0 +1,48 @@
+# ld-version-script.m4 serial 4
+dnl Copyright (C) 2008-2019 Free Software Foundation, Inc.
+dnl This file is free software; the Free Software Foundation
+dnl gives unlimited permission to copy and/or distribute it,
+dnl with or without modifications, as long as this notice is preserved.
+
+dnl From Simon Josefsson
+
+# FIXME: The test below returns a false positive for mingw
+# cross-compiles, 'local:' statements does not reduce number of
+# exported symbols in a DLL.  Use --disable-ld-version-script to work
+# around the problem.
+
+# gl_LD_VERSION_SCRIPT
+# --------------------
+# Check if LD supports linker scripts, and define automake conditional
+# HAVE_LD_VERSION_SCRIPT if so.
+AC_DEFUN([gl_LD_VERSION_SCRIPT],
+[
+  AC_ARG_ENABLE([ld-version-script],
+    [AS_HELP_STRING([--enable-ld-version-script],
+       [enable linker version script (default is enabled when possible)])],
+    [have_ld_version_script=$enableval],
+    [AC_CACHE_CHECK([if LD -Wl,--version-script works],
+       [gl_cv_sys_ld_version_script],
+       [gl_cv_sys_ld_version_script=no
+        save_LDFLAGS=$LDFLAGS
+        LDFLAGS="$LDFLAGS -Wl,--version-script=conftest.map"
+        echo foo >conftest.map
+        AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+          [],
+          [cat > conftest.map <<EOF
+VERS_1 {
+        global: sym;
+};
+
+VERS_2 {
+        global: sym;
+} VERS_1;
+EOF
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([], [])],
+             [gl_cv_sys_ld_version_script=yes])])
+        rm -f conftest.map
+        LDFLAGS=$save_LDFLAGS])
+     have_ld_version_script=$gl_cv_sys_ld_version_script])
+  AM_CONDITIONAL([HAVE_LD_VERSION_SCRIPT],
+    [test "$have_ld_version_script" = yes])
+])


### PR DESCRIPTION
Hi,

When I wanted to compile python audio-tools on my macOS 10.14 a few days ago and compiling the dependency libcdio-paranoia failed because the macOS linker doesn't support the --version-script argument.
Searching the internet showed that Simon Josefsson wrote a M4 script to check for that support.

With that PR the ld-version-script.m4 script was added, plus of course the necessary changes to the build files.

Could you have look at the PR and see if you find it useful? Compiling and the checks where successfully tested on macOS 10.14 and Ubuntu 19.10 64-bit.