### PR TITLE
Fix manpage path for Japanese

### DIFF
--- a/doc/ja/Makefile.am
+++ b/doc/ja/Makefile.am
@@ -15,7 +15,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-mansubdir=/jp/man1
+mansubdir=/ja/man1
 manfiles = cd-paranoia.1
 man_MANS = $(manfiles) cd-paranoia.1
 transform = s,cd-paranoia,@CDPARANOIA_NAME@,


### PR DESCRIPTION
Fix bug [#57736](https://savannah.gnu.org/bugs/?57736) on savanna.gnu.org "ja cd-paranoia.1 Makefile path incorrect", which actually was just a typo.