### PR TITLE
Add Travis-CI for macOS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+
+# just to make the config validator happy
+os: osx
+
+compiler:
+  - gcc
+
+addons:
+  homebrew:
+    packages:
+      - [ autoconf, automake, libcdio, pkg-config ]
+    update: true
+
+jobs:
+  include:
+    - os: osx
+      name: macOS
+      env:
+      osx_image: xcode9.4
+
+# run the tests
+script: autoreconf -i -f && ./configure && make && make check


### PR DESCRIPTION
Use Travis-CI to compile for macOS. They say don't do `brew update`
since it takes long. But their macOS image(s) are broken again so we
have to.

[The macos Image is broken](https://travis-ci.community/t/macos-build-fails-because-of-homebrew-bundle-unknown-command/7296/10)