### PR TITLE
Require libcdio at least 2.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ else
   unset warning_flags
 fi
 
-PKG_CHECK_MODULES(LIBCDIO, libcdio >= 0.83, [],
+PKG_CHECK_MODULES(LIBCDIO, libcdio >= 2.0.0, [],
 	[AC_MSG_ERROR(Required libcdio library not found. Please get libcdio from http://www.gnu.org/software/libcdio/ and install it.)])
 AC_SUBST(LIBCDIO_LIBS)
 AC_SUBST(LIBCDIO_CFLAGS)


### PR DESCRIPTION
I doubt 0.83 still works, although I haven't checked (and don't have much
interest in checking).

A *lot* has gone on since 0.83 so even if it still works, strong-arming
folks to get up to 2.0.0 is probably a good thing (from the developer
side if not the end-user side) in the long run.

And it isn't like 2.0.0 from the last day of 2017 is is all *that* new.