### PR TITLE
avoid triggering -Wstrict-prototypes compiler warnings

### DIFF
--- a/include/cdio/paranoia/cdda.h
+++ b/include/cdio/paranoia/cdda.h
@@ -222,7 +222,7 @@ cdrom_drive_t *cdio_cddap_identify_cdio(CdIo_t *p_cdio,
 
 /** informational functions */
 
-extern const char *cdio_cddap_version();
+extern const char *cdio_cddap_version(void);
 
 /** Returns the current message buffer. Free the returned
     string using cdio_cddap_free_messages() if not NULL.


### PR DESCRIPTION
This declaration is valid under C, but is considered an incomplete type because the type of the argument isn't specified. Fix this simply including the void here.