### PR TITLE
Fix error compilation to include stdint.h

### DIFF
--- a/include/cdio/paranoia/paranoia.h
+++ b/include/cdio/paranoia/paranoia.h
@@ -29,6 +29,7 @@
 #define CDIO__PARANOIA__PARANOIA_H_
 
 #include <cdio/paranoia/cdda.h>
+#include <stdint.h>
 
 /*! Paranoia likes to work with 16-bit numbers rather than
     (possibly byte-swapped) bytes. So there are this many

--- a/lib/cdda_interface/common_interface.c
+++ b/lib/cdda_interface/common_interface.c
@@ -30,6 +30,7 @@
 #include <math.h>
 #include "utils.h"
 #include "smallft.h"
+#include <stdint.h>
 
 /* Variables to hold debugger-helping enumerations */
 enum paranoia_cdda_enums;

--- a/lib/cdda_interface/utils.h
+++ b/lib/cdda_interface/utils.h
@@ -20,6 +20,7 @@
 #include <cdio/bytesex.h>
 #include <stdio.h>
 #include <time.h>
+#include <stdint.h>
 
 /* I wonder how many alignment issues this is gonna trip in the
    future...  it shouldn't trip any...  I guess we'll find out :) */

--- a/lib/paranoia/gap.h
+++ b/lib/paranoia/gap.h
@@ -19,6 +19,8 @@
 #ifndef _GAP_H_
 #define _GAP_H_
 
+#include <stdint.h>
+
 extern long i_paranoia_overlap_r(int16_t *buffA, int16_t *buffB, long offsetA,
                                  long offsetB);
 extern long i_paranoia_overlap_f(int16_t *buffA, int16_t *buffB, long offsetA,

--- a/lib/paranoia/isort.h
+++ b/lib/paranoia/isort.h
@@ -19,6 +19,8 @@
 #ifndef _ISORT_H_
 # define _ISORT_H_
 
+#include <stdint.h>
+
 typedef struct sort_link {
   struct sort_link *next;
 } sort_link_t;


### PR DESCRIPTION
This will fix issue to avoid error compilation by adding stdint.h on five files.