### PR TITLE
--all-sectors option, part 2

### DIFF
--- a/src/cd-paranoia.c
+++ b/src/cd-paranoia.c
@@ -938,7 +938,7 @@ int main(int argc, char *argv[]) {
   }
 
   if (optind >= argc && !query_only) {
-    if (batch)
+    if (batch || all_sectors)
       span = NULL;
     else {
       /* D'oh.  No span. Fetch me a brain, Igor. */

--- a/src/cd-paranoia.c
+++ b/src/cd-paranoia.c
@@ -694,6 +694,7 @@ int main(int argc, char *argv[]) {
   int query_only = 0;
   int batch = 0;
   int all_sectors = 0;
+  int span_set = 0;
   int run_cache_test = 0;
   long int force_cdrom_overlap = -1;
   long int force_cdrom_sectors = -1;
@@ -1189,6 +1190,10 @@ int main(int argc, char *argv[]) {
 
       /* explicitly turn off span, we're grabbing everything */
       span = 0;
+
+      /* check if both a span and --all-sectors were provided */
+      if (optind + 1 < argc)
+        span_set = 1;
     }
 
     if (span) {
@@ -1338,8 +1343,14 @@ int main(int argc, char *argv[]) {
         callbegin = batch_first;
         callend = batch_last;
 
-        /* argv[optind] is the span, argv[optind+1] (if exists) is outfile */
+        if (all_sectors) {
+          /* decrement optind to ignore an empty span so outfile can
+           * still be named correctly */
+          if (!span_set)
+            optind = optind - 1;
+        }
 
+        /* argv[optind] is the span, argv[optind+1] (if exists) is outfile */
         if (optind + 1 < argc) {
           if (!strcmp(argv[optind + 1], "-")) {
             out = dup(fileno(stdout));

--- a/src/cd-paranoia.c
+++ b/src/cd-paranoia.c
@@ -1324,6 +1324,7 @@ int main(int argc, char *argv[]) {
       while (cursor <= i_last_lsn) {
         char outfile_name[PATH_MAX];
         if (all_sectors) {
+          batch_first = cursor;
           batch_track = cdda_disc_firstsector(d);
           batch_last = cdda_disc_lastsector(d);
           if (batch_last > i_last_lsn)

--- a/src/cd-paranoia.c
+++ b/src/cd-paranoia.c
@@ -1189,7 +1189,7 @@ int main(int argc, char *argv[]) {
         report("Warning: all-sectors requested, overriding span");
 
       /* explicitly turn off span, we're grabbing everything */
-      span = 0;
+      span = NULL;
 
       /* check if both a span and --all-sectors were provided */
       if (optind + 1 < argc)

--- a/src/cd-paranoia.c
+++ b/src/cd-paranoia.c
@@ -1183,17 +1183,20 @@ int main(int argc, char *argv[]) {
     long batch_first;
     long batch_last;
     int batch_track;
+    char *span_copy = span;
 
     if (all_sectors) {
-      if (span)
-        report("Warning: all-sectors requested, overriding span");
-
-      /* explicitly turn off span, we're grabbing everything */
+      /* explicitly turn off span, we're grabbing everything,
+       * but save the argument itself for the report */
       span = NULL;
 
       /* check if both a span and --all-sectors were provided */
-      if (optind + 1 < argc)
+      if (optind + 1 < argc) {
+        report(
+            "WARNING: --all-sectors option overrides user-provided span (%s)\n",
+            span_copy);
         span_set = 1;
+      }
     }
 
     if (span) {

--- a/src/usage.txt.in
+++ b/src/usage.txt.in
@@ -133,5 +133,8 @@ A few examples, protected from the shell:
   C) extract from track 1, time 0:30.12 to 1:10.00:
        @CDPARANOIA_NAME@ "[:30.12]-1[1:10]"
 
+  D) extract the entire disc to a single file:
+       @CDPARANOIA_NAME@ -M
+
 Submit bug reports to bug-libcdio@gnu.org
 


### PR DESCRIPTION
Addresses a combination of things that were lingering after `--all-sectors` was merged.

* `cd-paranoia -vz --all-sectors [outfile]` would ignore the `outfile` name and use the default cdda.{wav|aiff|aifc|raw}
* A couple of general correctness and compiler warning fixes
* Only show the warning about span being overridden if the user specifies **both** `--all-sectors` and a span argument, and edit the message itself to be a bit more informative
* Allow `--all-sectors` to work without specifying an `outfile`, the case where you **do** want it to use the default cdda.{wav|aiff|aifc|raw} name
* Add a usage example