### PR TITLE
fix reading with negative offsets

### DIFF
--- a/src/cd-paranoia.c
+++ b/src/cd-paranoia.c
@@ -1284,9 +1284,14 @@ int main(int argc, char *argv[]) {
 
     /* Apply read sector offset to the first and last sector indices.
        If the option has not been given to force overreading, do not offset
-       the last sector index beyond the last sector of the final track.
+       the first/last sector index beyond the disc boundaries.
     */
     i_first_lsn += toc_offset;
+    long toc_leadin = 0;
+    if (!force_overread && i_first_lsn < 0) {
+      toc_leadin = -i_first_lsn;
+      i_first_lsn = 0;
+    }
     lsn_t lasttrack_lastsector = cdda_track_lastsector(d, d->tracks);
     if (!force_overread && i_last_lsn + toc_offset >= lasttrack_lastsector)
       i_last_lsn = lasttrack_lastsector;
@@ -1475,6 +1480,9 @@ int main(int argc, char *argv[]) {
             toc_offset > 0 && !force_overread) {
           sectorlen += toc_offset;
         }
+        if (toc_leadin > 0 && batch_first == i_first_lsn) {
+          sectorlen += toc_leadin;
+        }
         switch (output_type) {
         case 0: /* raw */
           break;
@@ -1490,6 +1498,20 @@ int main(int argc, char *argv[]) {
         }
 
         /* Off we go! */
+
+        /* Write sectors of silent audio to compensate for
+           missing samples that would be in the leadin */
+        if (toc_leadin > 0 && batch_first == i_first_lsn) {
+          char *silence;
+          size_t missing_sector_bytes = CD_FRAMESIZE_RAW * toc_leadin;
+
+          silence = calloc(toc_leadin, CD_FRAMESIZE_RAW);
+          if (!silence || buffering_write(out, silence, missing_sector_bytes)) {
+            report("Error writing output: %s", strerror(errno));
+            exit(1);
+          }
+          free(silence);
+        }
 
         if (offset_buffer_used) {
           /* partial sector from previous batch read */


### PR DESCRIPTION
When --sample-offset is negative, toc_offset can push i_first_lsn below sector 0, resulting in an invalid READ CD command.

```
INFO: ioctl CDROM_SEND_PACKET for command READ CD (0xbe) failed:
     Input/output error
```

 - clamp i_first_lsn to 0 (unless force_overread)
 - fill missing samples with silence in the pregap


I tested the changes with 2 drives
 - LG CRD-8522B with an offset of -419
 - LG GSA-4163B with an offset of +667

### Test with libcdio-paranoia

Ripped the 1st, 2nd, and last track of the same CD with the drives. The results are identical.

```
Commands:
libcdio-paranoia --verbose -d /dev/sr0 -O +667 1-1 # or 2-2, 16-16
libcdio-paranoia --verbose -d /dev/sr1 -O -491 1-1 # or 2-2, 16-16

Result:
71bc6d0c5548ad0cf3a31d346448d5323911211b99fc08854ebda520106d2ee4  cdda_track_01_CRD-8522B_-491.wav
71bc6d0c5548ad0cf3a31d346448d5323911211b99fc08854ebda520106d2ee4  cdda_track_01_GSA-4163B_+667.wav
453ca3714eb809c9037aa82b1878ff65cf2e40d3fb39edf63ad4d43d5a5c8f41  cdda_track_02_CRD-8522B_-491.wav
453ca3714eb809c9037aa82b1878ff65cf2e40d3fb39edf63ad4d43d5a5c8f41  cdda_track_02_GSA-4163B_+667.wav
f3b9c388118a51378381e4dde855661490850bcd3a96fbe4b8e12746a1b72cc2  cdda_track_16_CRD-8522B_-491.wav
f3b9c388118a51378381e4dde855661490850bcd3a96fbe4b8e12746a1b72cc2  cdda_track_16_GSA-4163B_+667.wav
```

### Test with whipper

Tested if whipper can correctly identify the drive's offset, and it was able to determine the correct offset for LG CRD-8522B as -491.
```
Command:
whipper offset find -d /dev/sr1

Result:
[...]
INFO:whipper.command.offset:trying read offset -24...
INFO:whipper.command.offset:trying read offset 704...
INFO:whipper.command.offset:trying read offset 572...
INFO:whipper.command.offset:trying read offset 1182...
INFO:whipper.command.offset:trying read offset 688...
INFO:whipper.command.offset:trying read offset -491...
INFO:whipper.command.offset:offset of device is likely -491, confirming...

Read offset of device is: -491.
INFO:whipper.command.offset:adding read offset to configuration file
```

Also ripped the CD with both drives and accuraterip reported correct rip in both cases.
```
Commands:
whipper cd -d /dev/sr0 rip -O ~/cd-out_GSA-4163B
whipper cd -d /dev/sr1 rip -O ~/cd-out_CRD-8522B

Result:
track  1: rip accurate     (max confidence    200) v1 [5cc31a92], v2 [adf22fe0], DB [5cc31a92, adf22fe0]
track  2: rip accurate     (max confidence    200) v1 [da2e00cf], v2 [b8a1cbe3], DB [da2e00cf, b8a1cbe3]
track  3: rip accurate     (max confidence    200) v1 [ed8c10c1], v2 [bdd5ef65], DB [ed8c10c1, bdd5ef65]
track  4: rip accurate     (max confidence    200) v1 [165aebbd], v2 [79b45054], DB [165aebbd, 79b45054]
track  5: rip accurate     (max confidence    200) v1 [b038d8c7], v2 [99c9b088], DB [b038d8c7, 99c9b088]
track  6: rip accurate     (max confidence    200) v1 [a9fd9865], v2 [e657ecb6], DB [a9fd9865, e657ecb6]
track  7: rip accurate     (max confidence    200) v1 [82ee1fde], v2 [a7bd0c24], DB [82ee1fde, a7bd0c24]
track  8: rip accurate     (max confidence    200) v1 [05da34cf], v2 [9cf3c8a5], DB [05da34cf, 9cf3c8a5]
track  9: rip accurate     (max confidence    200) v1 [694b8fe7], v2 [96240b8f], DB [694b8fe7, 96240b8f]
track 10: rip accurate     (max confidence    200) v1 [70708bb4], v2 [fdab62ed], DB [70708bb4, fdab62ed]
track 11: rip accurate     (max confidence    200) v1 [c1c9875c], v2 [31a69537], DB [c1c9875c, 31a69537]
track 12: rip accurate     (max confidence    200) v1 [55876e52], v2 [808245d8], DB [55876e52, 808245d8]
track 13: rip accurate     (max confidence    200) v1 [22f371fd], v2 [bf750bd3], DB [22f371fd, bf750bd3]
track 14: rip accurate     (max confidence    200) v1 [22d75da6], v2 [1f0cc90f], DB [22d75da6, 1f0cc90f]
track 15: rip accurate     (max confidence    200) v1 [3df7dbd2], v2 [98635782], DB [3df7dbd2, 98635782]
track 16: rip accurate     (max confidence    200) v1 [3932bc35], v2 [114463e0], DB [3932bc35, 114463e0]
```

Note: I used AI and Actual Intelligence to make this PR

Fixes #61 